### PR TITLE
Add nuget package context to staging and production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,24 +211,24 @@ workflows:
           filters:
             branches:
               only: master
-      - assume-role-production:
-          context: api-assume-role-production-context
-          requires:
-              - deploy-to-staging
-          filters:
-             branches:
-               only: master
       - permit-production-release:
           type: approval
           requires:
             - deploy-to-staging
           filters:
             branches:
-              only: master
+              only: master   
+      - assume-role-production:
+          context: api-assume-role-production-context
+          requires:
+              - permit-production-release
+          filters:
+             branches:
+               only: master
       - deploy-to-production:
           context: api-nuget-token-context
           requires:
-            - permit-production-release
+            - assume-role-production
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,6 +205,7 @@ workflows:
              branches:
                only: master
       - deploy-to-staging:
+          context: api-nuget-token-context
           requires:
             - assume-role-staging
           filters:
@@ -225,7 +226,7 @@ workflows:
             branches:
               only: master
       - deploy-to-production:
-          context: api-assume-role-housing-production-context
+          context: api-nuget-token-context
           requires:
             - permit-production-release
           filters:


### PR DESCRIPTION
## What
- added nuget package context to staging and production build steps

## Why
- This is required to access the nuget package to build the Lambda function prior to deployment.