### PR TITLE
Nuget permissions patch 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,24 +211,24 @@ workflows:
           filters:
             branches:
               only: master
-      - assume-role-production:
-          context: api-assume-role-production-context
-          requires:
-              - deploy-to-staging
-          filters:
-             branches:
-               only: master
       - permit-production-release:
           type: approval
           requires:
             - deploy-to-staging
           filters:
             branches:
-              only: master
+              only: master   
+      - assume-role-production:
+          context: api-assume-role-production-context
+          requires:
+              - permit-production-release
+          filters:
+             branches:
+               only: master
       - deploy-to-production:
           context: api-nuget-token-context
           requires:
-            - permit-production-release
+            - assume-role-production
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,8 @@ commands:
             cd ./FinancialTransactionsApi/
             apt-get update && apt-get install -y libjpeg62-turbo
             sls deploy --stage <<parameters.stage>> --account <<parameters.aws-account>> --conceal
-     
-            
+
+
 jobs:
   check-code-formatting:
     executor: docker-dotnet
@@ -192,11 +192,6 @@ workflows:
               only: development
   check-and-deploy-staging-and-production:
       jobs:
-      - build-and-test:
-          context: api-nuget-token-context
-          filters:
-            branches:
-              only: master
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:
@@ -217,7 +212,7 @@ workflows:
             - deploy-to-staging
           filters:
             branches:
-              only: master   
+              only: master
       - assume-role-production:
           context: api-assume-role-production-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,6 +205,7 @@ workflows:
              branches:
                only: master
       - deploy-to-staging:
+          context: api-nuget-token-context
           requires:
             - assume-role-staging
           filters:
@@ -225,7 +226,7 @@ workflows:
             branches:
               only: master
       - deploy-to-production:
-          context: api-assume-role-housing-production-context
+          context: api-nuget-token-context
           requires:
             - permit-production-release
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,23 +196,23 @@ workflows:
           context: api-assume-role-staging-context
           requires:
               - build-and-test
-          filters:
-             branches:
-               only: master
+#          filters:
+#             branches:
+#               only: master
       - deploy-to-staging:
           context: api-nuget-token-context
           requires:
             - assume-role-staging
-          filters:
-            branches:
-              only: master
+#          filters:
+#            branches:
+#              only: master
       - permit-production-release:
           type: approval
           requires:
             - deploy-to-staging
           filters:
             branches:
-              only: master
+              only: master   
       - assume-role-production:
           context: api-assume-role-production-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,10 @@ workflows:
               only: development
   check-and-deploy-staging-and-production:
       jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+      - build-and-test:
+          context: api-nuget-token-context
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:
@@ -212,7 +216,7 @@ workflows:
             - deploy-to-staging
           filters:
             branches:
-              only: master   
+              only: master
       - assume-role-production:
           context: api-assume-role-production-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,19 +197,19 @@ workflows:
       - build-and-test:
           context: api-nuget-token-context
       - assume-role-staging:
-          context: api-assume-role-staging-context
+          context: api-assume-role-housing-staging-context
           requires:
               - build-and-test
-#          filters:
-#             branches:
-#               only: master
+          filters:
+             branches:
+               only: master
       - deploy-to-staging:
           context: api-nuget-token-context
           requires:
             - assume-role-staging
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master
       - permit-production-release:
           type: approval
           requires:
@@ -218,7 +218,7 @@ workflows:
             branches:
               only: master
       - assume-role-production:
-          context: api-assume-role-production-context
+          context: api-assume-role-housing-production-context
           requires:
               - permit-production-release
           filters:


### PR DESCRIPTION
## What
- Updated deployment context

## Why
- This would allow it access to the correct environment and get the right variables.