### PR TITLE
Set timeout for lambda invocation

### DIFF
--- a/FinancialTransactionsApi/serverless.yml
+++ b/FinancialTransactionsApi/serverless.yml
@@ -3,6 +3,7 @@ provider:
   name: aws
   runtime: dotnetcore3.1
   memorySize: 2048
+  timeout: 29 # optional, in seconds, default is 6
   tracing:
     lambda: true
     apiGateway: true
@@ -19,6 +20,7 @@ functions:
     name: ${self:service}-${self:provider.stage}
     handler: FinancialTransactionsApi::FinancialTransactionsApi.LambdaEntryPoint::FunctionHandlerAsync
     role: lambdaExecutionRole
+    timeout: 29 # optional, in seconds, default is 6
     environment:
      REQUIRED_GOOGL_GROUPS: ${ssm:/housing-finance/${self:provider.stage}/authorization/required-google-groups}
      TRANSACTION_SNS_ARN: ${ssm:/sns-topic/${self:provider.stage}/financial-transactions_created/arn}


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

We're getting 502 (Bad gateway) response from thew API because of API timeout issue.

`Tue Feb 08 07:59:59 UTC 2022 : Endpoint request URI: https://lambda.eu-west-2.amazonaws.com/2015-03-31/functions/arn:aws:lambda:eu-west-2:364864573329:function:financial-transactions-api-development/invocations
Tue Feb 08 07:59:59 UTC 2022 : Endpoint request headers: {X-Amz-Date=20220208T075959Z, x-amzn-apigateway-api-id=26exrtxaid, Accept=application/json, User-Agent=AmazonAPIGateway_26exrtxaid, Host=lambda.eu-west-2.amazonaws.com, X-Amz-Content-Sha256=787e94f10cc2c9a64cea0106b1b1a5e214428b61d291b9b4f0aaa9be025f8f8e, X-Amzn-Trace-Id=Root=1-620222ff-7dde7489008366341944ee32, x-amzn-lambda-integration-tag=749a5dc6-665a-46f9-a26b-db6e63285960, Authorization=*********************************************************************************************************************************************************************************************************************************************************************************************************************************************1cbd7f, X-Amz-Source-Arn=arn:aws:execute-api:eu-west-2:364864573329:26exrtxaid/test-invoke-stage/POST/{proxy+}, X-Amz-Security-Token=IQoJb3JpZ2luX2VjEK///////////wEaCWV1LXdlc3QtMiJHMEUCIQDHr9IL4X7fvGv/x1oe4jhL9G4sA7yrJObhfq6NBCJJrwIgblBxFvfj4iytIfmd5bm7Z4S315jhVuKbjQ2D [TRUNCATED]
Tue Feb 08 07:59:59 UTC 2022 : Endpoint request body after transformations: {"resource":"/{proxy+}","path":"/api/v1/transactions","httpMethod":"POST","headers":{"Authorization":"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJncm91cHMiOlsiZTJlLXRlc3RpbmctZGV2ZWxvcG1lbnQiLCJlMmUtYXBpcy10ZXN0aW5nLWRldmVsb3BtZW50Il0sImVtYWlsIjoiZTJlLXRlc3RpbmctZGV2ZWxvcG1lbnRAaGFja25leS5nb3YudWsiLCJuYW1lIjoiZTJlLXRlc3RpbmctZGV2ZWxvcG1lbnQiLCJuYmYiOjE2MjQ4ODc5MzMsImV4cCI6MTk0MDQyMDczMywiaWF0IjoxNjI0ODg3OTMzfQ.3BbK2nCvqkkMI96PoFzkJG7bHmHIxYqizW9dbUFfG6Q","Content-Type":"application/json"},"multiValueHeaders":{"Authorization":["Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJncm91cHMiOlsiZTJlLXRlc3RpbmctZGV2ZWxvcG1lbnQiLCJlMmUtYXBpcy10ZXN0aW5nLWRldmVsb3BtZW50Il0sImVtYWlsIjoiZTJlLXRlc3RpbmctZGV2ZWxvcG1lbnRAaGFja25leS5nb3YudWsiLCJuYW1lIjoiZTJlLXRlc3RpbmctZGV2ZWxvcG1lbnQiLCJuYmYiOjE2MjQ4ODc5MzMsImV4cCI6MTk0MDQyMDczMywiaWF0IjoxNjI0ODg3OTMzfQ.3BbK2nCvqkkMI96PoFzkJG7bHmHIxYqizW9dbUFfG6Q"],"Content-Type":["application/json"]},"queryStringParameters":null,"multiValueQuery [TRUNCATED]
Tue Feb 08 07:59:59 UTC 2022 : Sending request to https://lambda.eu-west-2.amazonaws.com/2015-03-31/functions/arn:aws:lambda:eu-west-2:364864573329:function:financial-transactions-api-development/invocations
Tue Feb 08 08:00:05 UTC 2022 : Received response. Status: 200, Integration latency: 6026 ms
Tue Feb 08 08:00:05 UTC 2022 : Endpoint response headers: {Date=Tue, 08 Feb 2022 08:00:05 GMT, Content-Type=application/json, Content-Length=114, Connection=keep-alive, x-amzn-RequestId=b7608304-86ba-4742-a9db-f4b7b3b4327d, X-Amz-Function-Error=Unhandled, x-amzn-Remapped-Content-Length=0, X-Amz-Executed-Version=$LATEST, X-Amzn-Trace-Id=root=1-620222ff-7dde7489008366341944ee32;sampled=1}
Tue Feb 08 08:00:05 UTC 2022 : Endpoint response body before transformations: {"errorMessage":"2022-02-08T08:00:05.695Z b7608304-86ba-4742-a9db-f4b7b3b4327d Task timed out after 6.01 seconds"}
Tue Feb 08 08:00:05 UTC 2022 : Lambda execution failed with status 200 due to customer function error: 2022-02-08T08:00:05.695Z b7608304-86ba-4742-a9db-f4b7b3b4327d Task timed out after 6.01 seconds. Lambda request id: b7608304-86ba-4742-a9db-f4b7b3b4327d
Tue Feb 08 08:00:05 UTC 2022 : Method completed with status: 502`

### *What changes have we introduced*

Need ti increase timeout up to 29 seconds


