### PR TITLE
Updated the framework version and some packages.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
       - image: "hashicorp/terraform:light"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
 
 references:
   workspace_root: &workspace_root "~"
@@ -113,7 +113,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
+            curl -sL https://deb.nodesource.com/setup_14.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI

--- a/FinancialTransactionsApi.Tests/AwsIntegrationTests.cs
+++ b/FinancialTransactionsApi.Tests/AwsIntegrationTests.cs
@@ -82,12 +82,12 @@ namespace FinancialTransactionsApi.Tests
         private void CreateSnsTopic()
         {
             var snsAttrs = new Dictionary<string, string>();
-            snsAttrs.Add("fifo_topic", "true");
-            snsAttrs.Add("content_based_deduplication", "true");
+            snsAttrs.Add("FifoTopic", "true");
+            snsAttrs.Add("ContentBasedDeduplication", "true");
 
             var response = SimpleNotificationService.CreateTopicAsync(new CreateTopicRequest
             {
-                Name = "transactioncreated",
+                Name = "transactioncreated.fifo",
                 Attributes = snsAttrs
             }).Result;
 

--- a/FinancialTransactionsApi.Tests/Dockerfile
+++ b/FinancialTransactionsApi.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 
 # disable microsoft telematry

--- a/FinancialTransactionsApi.Tests/FinancialTransactionsApi.Tests.csproj
+++ b/FinancialTransactionsApi.Tests/FinancialTransactionsApi.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -26,11 +26,11 @@
     <PackageReference Include="Hackney.Core.JWT" Version="1.64.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Bogus" Version="25.0.4" />
     <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
     <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/FinancialTransactionsApi/Dockerfile
+++ b/FinancialTransactionsApi/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0
-RUN�apt-get update && apt-get -y install xvfb && apt-get -y install fontconfig && apt-get -y install libssl1.0-dev && apt-get -y install libx11-dev libx11-xcb-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-shm0-dev libxcb-util0-dev libxcb-xfixes0-dev libxcb-xkb-dev libxcb1-dev libxfixes-dev libxrandr-dev libxrender-dev
+RUN apt-get update && apt-get -y install xvfb && apt-get -y install fontconfig && apt-get -y install libssl1.0-dev && apt-get -y install libx11-dev libx11-xcb-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-shm0-dev libxcb-util0-dev libxcb-xfixes0-dev libxcb-xkb-dev libxcb1-dev libxfixes-dev libxrandr-dev libxrender-dev
 ENV DynamoDb_LocalMode='true'
 ENV Sns_LocalMode='true'
 

--- a/FinancialTransactionsApi/Dockerfile
+++ b/FinancialTransactionsApi/Dockerfile
@@ -1,5 +1,5 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
-RUN apt-get update && apt-get -y install xvfb && apt-get -y install fontconfig && apt-get -y install libssl1.0-dev && apt-get -y install libx11-dev libx11-xcb-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-shm0-dev libxcb-util0-dev libxcb-xfixes0-dev libxcb-xkb-dev libxcb1-dev libxfixes-dev libxrandr-dev libxrender-dev
+FROM mcr.microsoft.com/dotnet/sdk:6.0
+RUNï¿½apt-get update && apt-get -y install xvfb && apt-get -y install fontconfig && apt-get -y install libssl1.0-dev && apt-get -y install libx11-dev libx11-xcb-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-render-util0-dev libxcb-render0-dev libxcb-shm0-dev libxcb-util0-dev libxcb-xfixes0-dev libxcb-xkb-dev libxcb1-dev libxfixes-dev libxrandr-dev libxrender-dev
 ENV DynamoDb_LocalMode='true'
 ENV Sns_LocalMode='true'
 

--- a/FinancialTransactionsApi/FinancialTransactionsApi.csproj
+++ b/FinancialTransactionsApi/FinancialTransactionsApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
     <PropertyGroup>
@@ -30,10 +30,10 @@
         <PackageReference Include="LocalStack.Client" Version="1.2.2" />
         <PackageReference Include="LocalStack.Client.Extensions" Version="1.1.0" />
         <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
         <PackageReference Include="NodaMoney" Version="1.0.5" />
         <PackageReference Include="Razor.Templating.Core" Version="1.6.0" />
@@ -41,7 +41,7 @@
         <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.4.1" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
     </ItemGroup>
 
 

--- a/FinancialTransactionsApi/Startup.cs
+++ b/FinancialTransactionsApi/Startup.cs
@@ -49,9 +49,8 @@ namespace FinancialTransactionsApi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services
-                .AddMvc()
-                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+            services.AddMvc();
+
             services.AddApiVersioning(o =>
             {
                 o.DefaultApiVersion = new ApiVersion(1, 0);

--- a/FinancialTransactionsApi/V1/Infrastructure/ValidationExtensions.cs
+++ b/FinancialTransactionsApi/V1/Infrastructure/ValidationExtensions.cs
@@ -136,7 +136,7 @@ namespace FinancialTransactionsApi.V1.Infrastructure
             }
 
 
-            if (request.TargetId == null || request.TargetId == Guid.Empty)
+            if (request.TargetId == Guid.Empty)
             {
                 return false;
             }

--- a/FinancialTransactionsApi/build.cmd
+++ b/FinancialTransactionsApi/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/financial-transactions-api.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package bin/release/net6.0/financial-transactions-api.zip

--- a/FinancialTransactionsApi/build.sh
+++ b/FinancialTransactionsApi/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package ./bin/release/netcoreapp3.1/financial-transactions-api.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/financial-transactions-api.zip

--- a/FinancialTransactionsApi/serverless.yml
+++ b/FinancialTransactionsApi/serverless.yml
@@ -1,7 +1,7 @@
 service: financial-transactions-api
 provider:
   name: aws
-  runtime: dotnetcore3.1
+  runtime: dotnet6
   memorySize: 2048
   timeout: 29 # optional, in seconds, default is 6
   tracing:
@@ -13,7 +13,7 @@ provider:
   region: eu-west-2
 
 package:
-  artifact: ./bin/release/netcoreapp3.1/financial-transactions-api.zip
+  artifact: ./bin/release/net6.0/financial-transactions-api.zip
 
   plugins:
   - serverless-associate-waf  

--- a/data/pdf/Dockerfile
+++ b/data/pdf/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:3.1
+FROM public.ecr.aws/lambda/dotnet:6
 
 WORKDIR /var/task
 # For Rotativa SDK


### PR DESCRIPTION
# What:
 - An upgrade of the dotnet version from 3.1 to 6.
 - An upgrade of some of the packages that are needed for the newer version to get deployed/run.

# Why:
 - It's a mandatory piece of work due to security as the current (3.1) version is reaching its end of life.
 - Better performance.
 - Newer features & syntax.
 
# Notes:
 - These changes have already been deployed to development environment via the editing of the config within the `du-test` branch. Making HTTP requests with Insomnia seems to suggest that the code is working as expected. The merging of this PR to development branch will simply redeploy the exact same thing, but officially.
 - And obviously, all of the automated tests were made sure to pass.
 - Updated the local mock queue setup to be a fifo queue to avoid newly introduced localstack validation errors _([link](https://github.com/localstack/localstack/commit/357a789e0d6133104c35008e0f501b3ed70d876f#diff-412b833d2574a113c971d3d6e25434ac83c9f83a88bdac07d77ea6114d1a201dR663-R681))_. While the LocalStack Nuget packages stayed on constant version, the localstack docker image configured within docker composed was retrieving the latest image available.