### PR TITLE
Fix the database hostname key name for ssm access.

### DIFF
--- a/FinancialTransactionsApi/serverless.yml
+++ b/FinancialTransactionsApi/serverless.yml
@@ -31,7 +31,7 @@ functions:
      SubHeader: ${ssm:/housing-finance/${self:provider.stage}/report_export_settings_sub_header}
      Footer: ${ssm:/housing-finance/${self:provider.stage}/report_export_settings_footer}
      SubFooter: ${ssm:/housing-finance/${self:provider.stage}/report_export_settings_sub_footer}
-     CONNECTION_STRING: Host=${ssm:/housing-finance/${self:provider.stage}/hfs-postgres-hostname};Port=${ssm:/housing-finance/${self:provider.stage}/hfs-postgres-port};Database=${ssm:/housing-finance/${self:provider.stage}/hfs-postgres-database};Username=${ssm:/housing-finance/${self:provider.stage}/hfs-postgres-username};Password=${ssm:/housing-finance/${self:provider.stage}/hfs-postgres-password}
+     CONNECTION_STRING: Host=${ssm:/housing-finance/${self:provider.stage}/hfs-postgres-transactions-hostname};Port=${ssm:/housing-finance/${self:provider.stage}/hfs-postgres-port};Database=${ssm:/housing-finance/${self:provider.stage}/hfs-postgres-database};Username=${ssm:/housing-finance/${self:provider.stage}/hfs-postgres-username};Password=${ssm:/housing-finance/${self:provider.stage}/hfs-postgres-password}
     events:
       - http:
           path: /{proxy+}


### PR DESCRIPTION
# What:
 - Corrected they key name for the transactions read replica database host name.

# Why:
- So that all parts of the connection string could be successfully resolved.

# Notes:
Previous deployment failed due to failing to resolve part of the connection string upon lambda packaging time:

![image](https://user-images.githubusercontent.com/43747286/201100681-9df984bd-589a-4765-ab22-9ce9ef1107f2.png)